### PR TITLE
[RFR] Talk to wallaby

### DIFF
--- a/src/battlehill.cpp
+++ b/src/battlehill.cpp
@@ -1,10 +1,14 @@
+#include <battlecreek/analog_states.hpp>
+#include <battlecreek/battery_state.hpp>
+#include <battlecreek/digital_states.hpp>
 #include <battlecreek/motor_states.hpp>
 #include <battlecreek/servo_states.hpp>
-#include <battlecreek/digital_states.hpp>
-#include <battlecreek/analog_states.hpp>
 
 #include <daylite/node.hpp>
 #include <daylite/spinner.hpp>
+
+#include "wallaby_regs_p.hpp"
+#include "wallaby_p.hpp"
 
 #include <iostream>
 
@@ -12,8 +16,12 @@ using namespace battlecreek;
 using namespace daylite;
 using namespace std;
 
+
+static const unsigned int LED_PIN_NUM = 12;
+
 namespace
 {
+
   template<typename T>
   inline bson_bind::option<T> safe_unbind(const bson_t *raw_msg)
   {
@@ -65,6 +73,52 @@ namespace
   }
 }
 
+void config_led()
+{
+  unsigned short outputs = Private::Wallaby::instance()->readRegister16b(REG_RW_DIG_OE_H);
+
+  //  bit = 1 for output, 0 for input
+  outputs |= (1 << LED_PIN_NUM);
+
+  Private::Wallaby::instance()->writeRegister16b(REG_RW_DIG_OE_H, outputs);
+
+  usleep(1000);
+}
+
+// TODO: move/remove
+void blink_led()
+{
+
+  // led (on?)
+  unsigned short out;
+  out = Private::Wallaby::instance()->readRegister16b(REG_RW_DIG_OUT_H);
+  out |= (1 << LED_PIN_NUM);
+  Private::Wallaby::instance()->writeRegister16b(REG_RW_DIG_OUT_H, out);
+
+  usleep(20000);
+
+  // led (off?)
+  out = Private::Wallaby::instance()->readRegister16b(REG_RW_DIG_OUT_H);
+  out &= ~(1 << LED_PIN_NUM);
+  Private::Wallaby::instance()->writeRegister16b(REG_RW_DIG_OUT_H, out);
+  usleep(20000);
+}
+
+
+// TODO: move to battery source/header
+float power_level()
+{
+  // piece the 12-bit ADC result back together
+  unsigned short raw_batt_adc = Private::Wallaby::instance()->readRegister16b(REG_RW_BATT_H);
+
+  // calculate voltage based on linear curve-fitting
+  float batt_voltage = -0.02070635f + 0.009071161f * static_cast<float>(raw_batt_adc);
+
+  // FIXME   convert ADC->capacity  or  voltage->capacity
+
+  return batt_voltage;
+}
+
 
 int main(int argc, char *argv[])
 {
@@ -76,20 +130,30 @@ int main(int argc, char *argv[])
     return 1;
   }
   
+  auto analog_states_pub = n->advertise("robot/analog_states");
+  auto battery_state_pub = n->advertise("robot/battery_state");
+  auto digital_states_pub = n->advertise("robot/digital_states");
   auto motor_states_pub = n->advertise("robot/motor_states");
   auto servo_states_pub = n->advertise("robot/servo_states");
-  auto analog_states_pub = n->advertise("robot/analog_states");
-  auto digital_states_pub = n->advertise("robot/digital_states");
-  
-  auto set_motor_states_sub = n->subscribe("robot/set_motor_states", &set_motor_states_cb);
-  auto set_servo_states_sub = n->subscribe("robot/set_servo_states", &set_servo_states_cb);
+
   auto set_analog_states_sub = n->subscribe("robot/set_analog_states", &set_analog_states_cb);
   auto set_digital_states_sub = n->subscribe("robot/set_digital_states", &set_digital_states_cb);
+  auto set_motor_states_sub = n->subscribe("robot/set_motor_states", &set_motor_states_cb);
+  auto set_servo_states_sub = n->subscribe("robot/set_servo_states", &set_servo_states_cb);
   
+  // TODO: remove digital pin config
+  config_led();
+
   for(;;)
   {
-    
-    
+    blink_led();
+
+    // publish battery voltage
+    battlecreek::battery_state battery_state;
+    battery_state.capacity = power_level();
+    std::cout << "batt voltage = " << std::to_string(battery_state.capacity) << std::endl;
+    battery_state_pub->publish(battery_state.bind());
+
     spinner::spin_once();
   }
   

--- a/src/wallaby_p.cpp
+++ b/src/wallaby_p.cpp
@@ -1,0 +1,217 @@
+/*
+ * wallaby_p.cpp
+ *
+ *  Created on: Nov 2, 2015
+ *      Author: Joshua Southerland
+ */
+
+#include "wallaby_p.hpp"
+#include "wallaby_regs_p.hpp"
+
+#include <unistd.h>
+#include <cstdlib>
+#include <fcntl.h>
+#include <errno.h>
+#include <cstring>
+
+#include <sys/ioctl.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+
+#include <linux/types.h>
+#include <linux/spi/spidev.h>
+
+#include <string>
+#include <iostream>
+#include <iomanip> // std::hex
+
+
+namespace Private
+{
+
+Wallaby::Wallaby()
+: buffer_size_(REG_READABLE_COUNT),
+  read_buffer_(new unsigned char[REG_READABLE_COUNT]),
+  write_buffer_(new unsigned char[REG_READABLE_COUNT])
+{
+	static const std::string WALLABY_SPI_PATH = "/dev/spidev2.0";
+
+	// TODO: move spi code outside constructor
+	// TODO: handle device path better
+
+    spi_fd_ = open(WALLABY_SPI_PATH.c_str(), O_RDWR);
+    if (spi_fd_<=0)
+    {
+    		// TODO: ifndef guard std::cout calls
+            std::cout << "Device not found: " << WALLABY_SPI_PATH << std::endl;
+    }
+}
+
+Wallaby::~Wallaby()
+{
+	close(spi_fd_);
+	delete[] write_buffer_;
+	delete[] read_buffer_;
+}
+
+Wallaby * Wallaby::instance()
+{
+	static Wallaby instance;
+	return &instance;
+}
+
+bool Wallaby::transfer()
+{
+	if (spi_fd_ <= 0) return false; // TODO: feedback
+
+	// transfer counter - used to detect missed packets on co-proc side
+	static unsigned char count = 0;
+	count += 1;
+
+	write_buffer_[0] = 'J';        //start
+	write_buffer_[1] = 2;          // version 2
+	write_buffer_[2] = count;
+	write_buffer_[buffer_size_-1] = 'S'; // stop
+
+	struct spi_ioc_transfer	xfer[1];
+	memset(xfer, 0, sizeof xfer);
+
+	xfer[0].tx_buf = (unsigned long) write_buffer_;
+	xfer[0].rx_buf = (unsigned long) read_buffer_;
+	xfer[0].len = buffer_size_;
+
+	int status = ioctl(spi_fd_, SPI_IOC_MESSAGE(1), xfer);
+	usleep(50); //this  makes sure we don't outrun the co-processor until interrupts are in place for DMA
+
+	if (read_buffer_[0] != 'J')
+	{
+		std::cerr << " Error: DMA de-synchronized" << std::endl;
+
+		for (unsigned int i = 0; i < buffer_size_; ++i)
+		{
+			std::cerr << std::hex << static_cast<unsigned int>(read_buffer_[i]) << " ";
+		}
+		std::cerr << std::endl;
+
+		return false;
+	}
+
+	if (status < 0)
+   	{
+		std::cerr << "Error (SPI_IOC_MESSAGE): " << strerror(errno) << std::endl;
+		return false;
+	}
+
+	return true;
+}
+
+unsigned char Wallaby::readRegister8b(unsigned char address)
+{
+	if (address >= REG_READABLE_COUNT) return 0;// false; // TODO: feedback
+
+	clear_buffers();
+
+	//bool success = transfer();
+	//TODO: if (success == false) return false;
+	transfer();
+
+	unsigned char value = read_buffer_[address];
+	return value;
+}
+
+void Wallaby::writeRegister8b(unsigned char address, unsigned char value)
+{
+	if (address >= REG_ALL_COUNT) return;// false; // TODO: feedback
+
+	clear_buffers();
+
+	// TODO definitions for buffer inds
+	write_buffer_[3] = 1; // write 1 register
+	write_buffer_[4] = address; // at address 'address'
+	write_buffer_[5] = value; // with value 'value'
+
+	//TODO: bool success = transfer();
+	//return success;
+	transfer();
+}
+
+unsigned short Wallaby::readRegister16b(unsigned char address)
+{
+	if (address >= REG_READABLE_COUNT || address+1 >= REG_READABLE_COUNT) return 0;// false; // TODO: feedback
+
+	clear_buffers();
+
+	//TODO: bool success = transfer();
+	//return success;
+	transfer();
+
+	unsigned short value = (static_cast<unsigned short>(read_buffer_[address]) << 8) | read_buffer_[address+1];
+	return value;
+}
+
+void Wallaby::writeRegister16b(unsigned char address, unsigned short value)
+{
+	if (address >= REG_ALL_COUNT || address+1 >= REG_ALL_COUNT) return;// false; // TODO: feedback
+
+	clear_buffers();
+
+	// TODO definitions for buffer inds
+	write_buffer_[3] = 2; // write 2 registers
+	write_buffer_[4] = address; // at address 'address'
+	write_buffer_[5] = static_cast<unsigned char>((value & 0xFF00) >> 8);
+	write_buffer_[6] = address + 1;
+	write_buffer_[7] = static_cast<unsigned char>(value & 0x00FF);
+
+	//TODO: bool success = transfer();
+	//return success;
+	transfer();
+}
+
+unsigned int Wallaby::readRegister32b(unsigned char address)
+{
+	if (address >= REG_READABLE_COUNT || address+3 >= REG_READABLE_COUNT) return 0;// false; // TODO: feedback
+
+	clear_buffers();
+
+	//TODO: bool success = transfer();
+	//return success;
+	transfer();
+
+	unsigned int value =
+			  (static_cast<unsigned int>(read_buffer_[address]) << 24)
+			| (static_cast<unsigned int>(read_buffer_[address+1]) << 16)
+			| (static_cast<unsigned int>(read_buffer_[address+2]) << 8)
+			| (static_cast<unsigned int>(read_buffer_[address+3]));
+
+	return value;
+}
+
+void Wallaby::writeRegister32b(unsigned char address, unsigned int value)
+{
+	if (address >= REG_ALL_COUNT || address+3 >= REG_ALL_COUNT) return;// false; // TODO: feedback
+
+	clear_buffers();
+
+	// TODO definitions for buffer inds
+	write_buffer_[3] = 2; // write 2 registers
+	write_buffer_[4] = address; // at address 'address'
+	write_buffer_[5] = static_cast<unsigned char>((value & 0xFF000000) >> 24);
+	write_buffer_[6] = address + 1;
+	write_buffer_[7] = static_cast<unsigned char>((value & 0x00FF0000) >> 16);
+	write_buffer_[8] = address + 2;
+	write_buffer_[9] = static_cast<unsigned char>((value & 0x0000FF00) >> 8);
+	write_buffer_[10] = address + 3;
+	write_buffer_[11] = static_cast<unsigned char>((value & 0x000000FF));
+
+	//TODO: bool success = transfer();
+	//return succes2;
+	transfer();
+}
+
+void Wallaby::clear_buffers()
+{
+	memset(write_buffer_, 0, buffer_size_);
+	memset(read_buffer_, 0, buffer_size_);
+}
+
+} /* namespace Private */

--- a/src/wallaby_p.hpp
+++ b/src/wallaby_p.hpp
@@ -1,0 +1,44 @@
+/*
+ * wallaby_p.hpp
+ *
+ *  Created on: Nov 2, 2015
+ *      Author: Joshua Southerland
+ */
+
+#ifndef SRC_WALLABY_P_HPP_
+#define SRC_WALLABY_P_HPP_
+
+namespace Private
+{
+
+class Wallaby
+{
+
+public:
+	static Wallaby * instance();
+
+	unsigned char readRegister8b(unsigned char address);
+	void writeRegister8b(unsigned char address, unsigned char value);
+
+	unsigned short readRegister16b(unsigned char address);
+	void writeRegister16b(unsigned char address, unsigned short value);
+
+	unsigned int readRegister32b(unsigned char address);
+	void writeRegister32b(unsigned char address, unsigned int value);
+
+	virtual ~Wallaby();
+
+private:
+	Wallaby();
+	bool transfer();
+	void clear_buffers();
+	int spi_fd_;
+	unsigned char * write_buffer_;
+	unsigned char * read_buffer_;
+	const unsigned int buffer_size_;
+
+};
+
+} /* namespace Private */
+
+#endif /* SRC_WALLABY_P_HPP_ */

--- a/src/wallaby_regs_p.hpp
+++ b/src/wallaby_regs_p.hpp
@@ -1,0 +1,216 @@
+/*
+ * wallaby_regs_p.hpp
+ *
+ *  Created on: Nov 2, 2015
+ *      Author: Joshua Southerland
+ */
+
+namespace Private
+{
+
+#ifndef SRC_WALLABY_REGS_P_HPP_
+#define SRC_WALLABY_REGS_P_HPP_
+
+
+
+#define WALLABY_SPI_VERSION 1
+
+// READ Only Registers ---------------------------------------------------------
+#define REG_R_START        0
+
+// READ/Write Registers --------------------------------------------------------
+
+#define REG_RW_DIG_IN_H    1
+#define REG_RW_DIG_IN_L    2
+#define REG_RW_DIG_OUT_H   3
+#define REG_RW_DIG_OUT_L   4
+#define REG_RW_DIG_PE_H    5
+#define REG_RW_DIG_PE_L    6
+#define REG_RW_DIG_OE_H    7
+#define REG_RW_DIG_OE_L    8
+
+#define REG_RW_ADC_0_H     9
+#define REG_RW_ADC_0_L     10
+#define REG_RW_ADC_1_H     11
+#define REG_RW_ADC_1_L     12
+#define REG_RW_ADC_2_H     13
+#define REG_RW_ADC_2_L     14
+#define REG_RW_ADC_3_H     15
+#define REG_RW_ADC_3_L     16
+#define REG_RW_ADC_4_H     17
+#define REG_RW_ADC_4_L     18
+#define REG_RW_ADC_5_H     19
+#define REG_RW_ADC_5_L     20
+#define REG_RW_ADC_PE      21 // low 6 bits used
+
+#define REG_RW_MAG_X_H     22
+#define REG_RW_MAG_X_L     23
+#define REG_RW_MAG_Y_H     24
+#define REG_RW_MAG_Y_L     25
+#define REG_RW_MAG_Z_H     26
+#define REG_RW_MAG_Z_L     27
+
+#define REG_RW_ACCEL_X_H   28
+#define REG_RW_ACCEL_X_L   29
+#define REG_RW_ACCEL_Y_H   30
+#define REG_RW_ACCEL_Y_L   31
+#define REG_RW_ACCEL_Z_H   32
+#define REG_RW_ACCEL_Z_L   33
+
+#define REG_RW_GYRO_X_H    34
+#define REG_RW_GYRO_X_L    35
+#define REG_RW_GYRO_Y_H    36
+#define REG_RW_GYRO_Y_L    37
+#define REG_RW_GYRO_Z_H    38
+#define REG_RW_GYRO_Z_L    39
+
+// Motor 0 position
+#define REG_RW_MOT_0_B3    40
+#define REG_RW_MOT_0_B2    41
+#define REG_RW_MOT_0_B1    42
+#define REG_RW_MOT_0_B0    43
+
+// Motor 1 position
+#define REG_RW_MOT_1_B3    44
+#define REG_Rw_MOT_1_B2    45
+#define REG_Rw_MOT_1_B1    46
+#define REG_RW_MOT_1_B0    47
+
+// Motor 2 position
+#define REG_RW_MOT_2_B3    48
+#define REG_RW_MOT_2_B2    49
+#define REG_RW_MOT_2_B1    50
+#define REG_RW_MOT_2_B0    51
+
+// Motor 3 position
+#define REG_RW_MOT_3_B3    52
+#define REG_RW_MOT_3_B2    53
+#define REG_RW_MOT_3_B1    54
+#define REG_RW_MOT_3_B0    55
+
+#define REG_RW_MOT_MODES   56  //   Normal PWM, MTP, MAV, MRP, 2 bits per motor
+#define REG_RW_MOT_DIRS    57  //   IDLE, FORWARD, REVERSE, BREAK, 2 bits per motor
+#define REG_RW_MOT_DONE    58  //   4 lowest bit used:   0000 (chan0) (chan1) (chan2) (chan3)
+#define REG_RW_MOT_SRV_ALLSTOP 59 //  2nd lowest bit is motor all stop, lowest bit is servo allstop
+
+// 16 bit signed speed goals
+#define REG_RW_MOT_0_SP_H  60
+#define REG_RW_MOT_0_SP_L  61
+#define REG_RW_MOT_1_SP_H  62
+#define REG_RW_MOT_1_SP_L  63
+#define REG_RW_MOT_2_SP_H  64
+#define REG_RW_MOT_2_SP_L  65
+#define REG_RW_MOT_3_SP_H  66
+#define REG_RW_MOT_3_SP_L  67
+
+// 16 bit unsigned pwms, from the user or PID controller
+#define REG_RW_MOT_0_PWM_H  68
+#define REG_RW_MOT_0_PWM_L  69
+#define REG_RW_MOT_1_PWM_H  70
+#define REG_RW_MOT_1_PWM_L  71
+#define REG_RW_MOT_2_PWM_H  72
+#define REG_RW_MOT_2_PWM_L  73
+#define REG_RW_MOT_3_PWM_H  74
+#define REG_RW_MOT_3_PWM_L  75
+
+// 16 bit unsigned servo goals
+// microsecond servo pulse, where 1500 is neutral
+// +/- about 10 per degree from neutral
+#define REG_RW_SERVO_0_H   76
+#define REG_RW_SERVO_0_L   77
+#define REG_RW_SERVO_1_H   78
+#define REG_RW_SERVO_1_L   79
+#define REG_RW_SERVO_2_H   80
+#define REG_RW_SERVO_2_L   81
+#define REG_RW_SERVO_3_H   82
+#define REG_RW_SERVO_3_L   83
+
+// 12 bit unsigned int adc result
+#define REG_RW_BATT_H      84
+#define REG_RW_BATT_L      85
+
+#define REG_READABLE_COUNT 86
+
+
+
+// WRITE ONLY Registers---------------------------------------------------------
+#define REG_W_PID_0_P_H    86
+#define REG_W_PID_0_P_L    87
+#define REG_W_PID_0_PD_H   88
+#define REG_W_PID_0_PD_L   89
+#define REG_W_PID_0_I_H    90
+#define REG_W_PID_0_I_L    91
+#define REG_W_PID_0_ID_H   92
+#define REG_W_PID_0_ID_L   93
+#define REG_W_PID_0_D_H    94
+#define REG_W_PID_0_D_L    95
+#define REG_W_PID_0_DD_H   96
+#define REG_W_PID_0_DD_L   97
+#define REG_W_PID_1_P_H    98
+#define REG_W_PID_1_P_L    99
+#define REG_W_PID_1_PD_H   100
+#define REG_W_PID_1_PD_L   101
+#define REG_W_PID_1_I_H    102
+#define REG_W_PID_1_I_L    104
+#define REG_W_PID_1_ID_H   103
+#define REG_W_PID_1_ID_L   104
+#define REG_W_PID_1_D_H    105
+#define REG_W_PID_1_D_L    106
+#define REG_W_PID_1_DD_H   107
+#define REG_W_PID_1_DD_L   108
+#define REG_W_PID_2_P_H    109
+#define REG_W_PID_2_P_L    110
+#define REG_W_PID_2_PD_H   111
+#define REG_W_PID_2_PD_L   112
+#define REG_W_PID_2_I_H    113
+#define REG_W_PID_2_I_L    114
+#define REG_W_PID_2_ID_H   115
+#define REG_W_PID_2_ID_L   116
+#define REG_W_PID_2_D_H    117
+#define REG_W_PID_2_D_L    118
+#define REG_W_PID_2_DD_H   119
+#define REG_W_PID_2_DD_L   120
+
+#define REG_W_PID_3_P_H    121
+#define REG_W_PID_3_P_L    122
+#define REG_W_PID_3_PD_H   123
+#define REG_W_PID_3_PD_L   124
+#define REG_W_PID_3_I_H    125
+#define REG_W_PID_3_I_L    126
+#define REG_W_PID_3_ID_H   127
+#define REG_W_PID_3_ID_L   128
+#define REG_W_PID_3_D_H    129
+#define REG_W_PID_3_D_L    130
+#define REG_W_PID_3_DD_H   131
+#define REG_W_PID_3_DD_L   132
+
+
+// Motor 0 position goal
+#define REG_W_MOT_0_GOAL_B3    133
+#define REG_W_MOT_0_GOAL_B2    134
+#define REG_W_MOT_0_GOAL_B1    135
+#define REG_W_MOT_0_GOAL_B0    136
+
+// Motor 1 position goal
+#define REG_W_MOT_1_GOAL_B3    137
+#define REG_w_MOT_1_GOAL_B2    138
+#define REG_w_MOT_1_GOAL_B1    139
+#define REG_W_MOT_1_GOAL_B0    140
+
+// Motor 2 position goal
+#define REG_W_MOT_2_GOAL_B3    141
+#define REG_W_MOT_2_GOAL_B2    142
+#define REG_W_MOT_2_GOAL_B1    143
+#define REG_W_MOT_2_GOAL_B0    144
+
+// Motor 3 position goal
+#define REG_W_MOT_3_GOAL_B3    145
+#define REG_W_MOT_3_GOAL_B2    146
+#define REG_W_MOT_3_GOAL_B1    147
+#define REG_W_MOT_3_GOAL_B0    148
+
+#define REG_ALL_COUNT      149
+
+}
+
+#endif /* SRC_WALLABY_REGS_P_HPP_ */


### PR DESCRIPTION
These commits add a list of wallaby registers we will be using and some basic communication with the co-processor.  

Much of this code may be changed/removed in the near future, but for now it demonstrates toggling a LED as a heartbeat and publishes the battery voltage on `robot/battery_state`
